### PR TITLE
83 bug rediscachedrepository use settings instead of configuration

### DIFF
--- a/Stocks.Core/Cache/RedisCachedRepository.cs
+++ b/Stocks.Core/Cache/RedisCachedRepository.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using StackExchange.Redis;
 using Stocks.Core.Enums;
@@ -9,9 +9,9 @@ namespace Stocks.Core.Cache
     {
         readonly string _redisConnectionString;
 
-        public RedisCachedRepository(IConfiguration configuration)
+        public RedisCachedRepository(IOptions<Settings> settings)
         {
-            _redisConnectionString = configuration.GetConnectionString("Redis");
+            _redisConnectionString = settings.Value.Redis;
         }
 
         public T Get<T>(string key)

--- a/Stocks.Core/Settings.cs
+++ b/Stocks.Core/Settings.cs
@@ -1,4 +1,4 @@
-﻿namespace Stocks.DividendUpdater;
+﻿namespace Stocks.Core;
 public class Settings
 {
     public const string SectionName = "ConnectionStrings";

--- a/Stocks.DividendUpdater/Stocks.DividendUpdater.csproj
+++ b/Stocks.DividendUpdater/Stocks.DividendUpdater.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <Content Include="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>

--- a/Stocks.Tests/ConfigurationBuilderBuilder.cs
+++ b/Stocks.Tests/ConfigurationBuilderBuilder.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Stocks.Core;
 
 namespace Stocks.Test
 {
@@ -8,5 +10,8 @@ namespace Stocks.Test
         => new ConfigurationBuilder()
                 .AddJsonFile($"appsettings.Development.json", optional: false)
                 .Build();
+
+        public static IOptions<Settings> GetOptions()
+        => Options.Create(new Settings { Redis = Build().GetConnectionString("Redis") });
     }
 }

--- a/Stocks.Tests/RedisCacheTests.cs
+++ b/Stocks.Tests/RedisCacheTests.cs
@@ -10,7 +10,7 @@ namespace WebDownloading.Test
         [SetUp]
         public void Setup()
         {
-            _target = new RedisCachedRepository(ConfigurationBuilderBuilder.Build());
+            _target = new RedisCachedRepository(ConfigurationBuilderBuilder.GetOptions());
         }
 
         [Test]

--- a/Stocks.Web/Startup.cs
+++ b/Stocks.Web/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Stocks.Core;
 using Stocks.Core.Cache;
 using Stocks.Core.DividendDisplay;
 using Stocks.Core.Loaders;
@@ -39,6 +40,7 @@ namespace Stocks.Web
             services.AddTransient<ICalendarGenerator, CalendarGenerator>();
             services.AddTransient<IDateProvider, DateProvider>();
             services.AddDbContext<StockContext>(options => options.UseSqlServer(Configuration.GetConnectionString("StockWebDividendDB")));
+            services.AddOptions<Settings>().Bind(Configuration.GetSection(Settings.SectionName));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
# Description

`RedisCachedRepository` gets the connection string value by `IOptions`

Fixes # (issue)
Closes #83 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
